### PR TITLE
Add support for sitelinks

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,9 +10,11 @@ from .propertypath import *
 from .utils import *
 from wdreconcile import subfields
 from wdreconcile import wikidatavalue
+from wdreconcile import sitelink
 
 import doctest
 def load_tests(loader, tests, ignore):
     tests.addTests(doctest.DocTestSuite(subfields))
     tests.addTests(doctest.DocTestSuite(wikidatavalue))
+    tests.addTests(doctest.DocTestSuite(sitelink))
     return tests

--- a/tests/engine.py
+++ b/tests/engine.py
@@ -97,6 +97,9 @@ class ReconcileEngineTest(unittest.TestCase):
         self.assertTrue(
             self.best_score('Oxford', properties=[{'pid':'P17', 'v':'https://en.wikipedia.org/wiki/Cambridge'}])
             < 90)
+        self.assertEqual(
+            self.best_score('Oxford', properties=[{'pid':'P17', 'v':'https://en.wikipedia.org/wiki/United Kingdom'}]),
+            100)
 
     def test_unique_id(self):
         """

--- a/tests/engine.py
+++ b/tests/engine.py
@@ -87,6 +87,17 @@ class ReconcileEngineTest(unittest.TestCase):
             self.best_score('Q29568422'),
             100)
 
+    def test_sitelink(self):
+        self.assertEqual(
+            self.best_match_id('https://de.wikipedia.org/wiki/Chelsea Manning'),
+            'Q298423')
+        self.assertEqual(
+            self.best_score('https://de.wikipedia.org/wiki/Chelsea Manning'),
+            100)
+        self.assertTrue(
+            self.best_score('Oxford', properties=[{'pid':'P17', 'v':'https://en.wikipedia.org/wiki/Cambridge'}])
+            < 90)
+
     def test_unique_id(self):
         """
         We can fetch items by unique ids!

--- a/wdreconcile/itemstore.py
+++ b/wdreconcile/itemstore.py
@@ -1,6 +1,7 @@
 import requests
 import json
 from .language import language_fallback
+from .sitelink import SitelinkFetcher
 
 class ItemStore(object):
     """
@@ -12,6 +13,7 @@ class ItemStore(object):
         self.prefix = 'openrefine_wikidata:items'
         self.ttl = 60*60 # one hour
         self.max_items_per_fetch = 50 # constraint from the Wikidata API
+        self.sitelink_fetcher = SitelinkFetcher(redis_client)
 
     def get_item(self, qid, force=False):
         """

--- a/wdreconcile/sitelink.py
+++ b/wdreconcile/sitelink.py
@@ -1,0 +1,124 @@
+
+import re
+
+from .sparqlwikidata import sparql_wikidata
+from .utils import to_q
+
+class SitelinkFetcher(object):
+    """
+    Fetches Qids by sitelinks.
+    """
+
+    # https://www.mediawiki.org/wiki/Manual:$wgLegalTitleChars
+    legal_title_chars = " %!\"$&'()*,\\-.\\/0-9:;=?@A-Z\\\\^_`a-z~\\x80-\\xFF+"
+
+    wikimedia_sites = '|'.join([
+        'wikipedia',
+        'wikisource',
+        'wikivoyage',
+        'wikiquote',
+        'wikinews',
+        'wikiversity',
+        'wiktionary',
+    ])
+
+    wikimedia_sites_without_capitalization = [
+        'wiktionary',
+    ]
+
+    sitelink_regex = re.compile(
+        r'^https?://([a-z]*)\.('+wikimedia_sites+')\.org/wiki/(['+legal_title_chars+']+)$')
+
+    @classmethod
+    def normalize(cls, sitelink):
+        """
+        Given a candidate sitelink, normalize it,
+        or returns None if it does not represent a sitelink.
+
+        >>> SitelinkFetcher.normalize('http://en.wikipedia.org/wiki/cluny')
+        'https://en.wikipedia.org/wiki/Cluny'
+        >>> SitelinkFetcher.normalize(' http://fr.wikipedia.org/wiki/Alan%20Turing ')
+        'https://fr.wikipedia.org/wiki/Alan_Turing'
+        >>> SitelinkFetcher.normalize('https://de.wikiquote.org/wiki/Chelsea Manning')
+        'https://de.wikiquote.org/wiki/Chelsea_Manning'
+        >>> SitelinkFetcher.normalize('https://www.wikimedia.org/') is None
+        True
+        >>> SitelinkFetcher.normalize('https://fr.wikipedia.org/wiki/') is None
+        True
+        """
+        if not sitelink:
+            return None
+        sitelink = str(sitelink).strip()
+        match = cls.sitelink_regex.match(sitelink)
+        if not match:
+            return None
+        cleaned_title = match.group(3).replace('%20', ' ').replace(' ', '_')
+        wiki = match.group(2)
+        if wiki not in cls.wikimedia_sites_without_capitalization:
+            cleaned_title = cleaned_title[0].upper()+cleaned_title[1:]
+        return 'https://{}.{}.org/wiki/{}'.format(
+            match.group(1),
+            wiki,
+            cleaned_title)
+
+    @classmethod
+    def get_qids(cls, sitelinks):
+        """
+        Given a list of candidate sitelinks, return a list of
+        the Qids they are associated to (or None if they are invalid,
+        or not linked yet).
+
+        >>> SitelinkFetcher.get_qids(['https://de.wikipedia.org/wiki/Chelsea Manning', 'http://gnu.org'])
+        ['Q298423', None]
+        >>> SitelinkFetcher.get_qids(['https://a.com/', 'http://b.org/']) # no request made
+        [None, None]
+        """
+        result = [None] * len(sitelinks)
+
+        normalized_sitelinks = [
+            cls.normalize(sitelink)
+            for sitelink in sitelinks
+        ]
+
+        if all(sitelink is None for sitelink in normalized_sitelinks):
+            return result
+
+        sitelink_list = ' '.join(
+           '<%s>' % sitelink
+            for sitelink in normalized_sitelinks
+            if sitelink
+        )
+
+        query = """
+        PREFIX schema: <http://schema.org/>
+        SELECT ?item ?sitelink WHERE {
+        ?sitelink schema:about ?item .
+        VALUES ?sitelink { %s }
+        }
+        """ % sitelink_list
+
+        for binding in sparql_wikidata(query)['bindings']:
+            qid = to_q(binding["item"]["value"])
+            sitelink = binding["sitelink"]["value"]
+            try:
+                idx = normalized_sitelinks.index(sitelink)
+                result[idx] = qid
+            except ValueError:
+                print('Normalization error for sitelink: "{}"'.format(sitelink))
+
+        return result
+
+    @classmethod
+    def sitelinks_to_qids(cls, sitelinks):
+        """
+        Same as get_qids, but returns a dictionary from the sitelinks to the qids
+
+        >>> SitelinkFetcher.sitelinks_to_qids(['https://de.wikipedia.org/wiki/Chelsea Manning'])
+        {'https://de.wikipedia.org/wiki/Chelsea_Manning': 'Q298423'}
+        """
+        normalized = list(map(cls.normalize, sitelinks))
+        qids = cls.get_qids(normalized)
+        return {
+            sitelink:qid
+            for sitelink, qid in zip(normalized, qids)
+        }

--- a/wdreconcile/wikidatavalue.py
+++ b/wdreconcile/wikidatavalue.py
@@ -137,7 +137,9 @@ class ItemValue(WikidataValue):
         # Then check for a sitelink
         sitelink = SitelinkFetcher.normalize(s)
         if sitelink:
-            return 100 # TODO cache sitelinks and do as above
+            target_qid = item_store.sitelink_fetcher.sitelinks_to_qids(
+                [sitelink]).get(sitelink)
+            return 100 if target_qid == self.id else 0
 
         # Then check for a novalue match
         if not s and self.is_novalue():

--- a/wdreconcile/wikidatavalue.py
+++ b/wdreconcile/wikidatavalue.py
@@ -2,6 +2,7 @@ import dateutil.parser
 from urllib.parse import urlparse, urlunparse
 import math
 
+from .sitelink import SitelinkFetcher
 from .utils import to_q, fuzzy_match_strings, match_ints, match_floats
 
 wdvalue_mapping = {}
@@ -133,6 +134,10 @@ class ItemValue(WikidataValue):
         qid = to_q(s)
         if qid:
             return 100 if qid == self.id else 0
+        # Then check for a sitelink
+        sitelink = SitelinkFetcher.normalize(s)
+        if sitelink:
+            return 100 # TODO cache sitelinks and do as above
 
         # Then check for a novalue match
         if not s and self.is_novalue():


### PR DESCRIPTION
Reconciling a column with sitelinks (e.g. "http://en.wikipedia.org/wiki/OpenRefine") will reconcile them to their corresponding Wikidata items. Sitelinks in columns used for properties are also supported.